### PR TITLE
debugged setting size automatically when ndim_idx > 1

### DIFF
--- a/numpy_groupies/utils_numpy.py
+++ b/numpy_groupies/utils_numpy.py
@@ -263,7 +263,7 @@ def input_validation(group_idx, a, size=None, order='C', axis=None,
         flat_size = size
     else:
         if size is None:
-            size = int(np.max(group_idx, axis=1)) + 1
+            size = np.max(group_idx, axis=1).astype(int) + 1
         elif np.isscalar(size):
             raise ValueError("output size must be of length %d"
                              % len(group_idx))


### PR DESCRIPTION
debugged setting size automatically when ndim_idx > 1

e.g., the following code threw an error that an array cannot be converted to a python scalar. This commit fixes the problem.
```
import numpy as np
import numpy_groupies as npg
out = npg.aggregate(np.ones([2, 3], dtype=int), np.ones([3]))
```

Tested on python 3.7, numpy 1.19.2.