### PR TITLE
Faster input validation

### DIFF
--- a/numpy_groupies/utils_numpy.py
+++ b/numpy_groupies/utils_numpy.py
@@ -189,7 +189,7 @@ def check_group_idx(group_idx, a=None, check_min=True):
         raise ValueError("group_idx contains negative indices")
 
 
-def _ravel_group_idx(group_idx, a, axis, size, order):
+def _ravel_group_idx(group_idx, a, axis, size, order, method="ravel"):
     ndim_a = a.ndim
     # Create the broadcast-ready multidimensional indexing.
     # Note the user could do this themselves, so this is
@@ -199,20 +199,43 @@ def _ravel_group_idx(group_idx, a, axis, size, order):
     group_idx = []
     size = []
     for ii, s in enumerate(a.shape):
-        ii_idx = group_idx_in if ii == axis else np.arange(s)
-        ii_shape = [1] * ndim_a
-        ii_shape[ii] = s
-        group_idx.append(ii_idx.reshape(ii_shape))
+        if method == "ravel":
+            ii_idx = group_idx_in if ii == axis else np.arange(s)
+            ii_shape = [1] * ndim_a
+            ii_shape[ii] = s
+            group_idx.append(ii_idx.reshape(ii_shape))
         size.append(size_in if ii == axis else s)
     # Use the indexing, and return. It's a bit simpler than
     # using trying to keep all the logic below happy
-    group_idx = np.ravel_multi_index(group_idx, size, order=order,
-                                     mode='raise')
+    if method == "ravel":
+        group_idx = np.ravel_multi_index(group_idx, size, order=order,
+                                         mode='raise')
+    elif method == "offset":
+        group_idx = offset_labels(group_idx_in, a.shape, axis, order, size_in)
     return group_idx, size
 
+def offset_labels(group_idx, inshape, axis, order, size):
+    """
+    Offset group labels by dimension. This is used when we
+    reduce over a subset of the dimensions of by. It assumes that the reductions
+    dimensions have been flattened in the last dimension
+    Copied from
+    https://stackoverflow.com/questions/46256279/bin-elements-per-row-vectorized-2d-bincount-for-numpy
+    """
+    if axis not in (-1, len(inshape) - 1):
+        newshape = (s for idx, s in enumerate(inshape) if idx != axis) + (inshape[axis],)
+    else:
+        newshape = inshape
+    group_idx = np.broadcast_to(group_idx, newshape)
+    group_idx: np.ndarray = (
+        group_idx
+        + np.arange(np.prod(group_idx.shape[:-1]), dtype=int).reshape((*group_idx.shape[:-1], -1))
+        * size
+    )
+    return group_idx.reshape(inshape).ravel()
 
 def input_validation(group_idx, a, size=None, order='C', axis=None,
-                     ravel_group_idx=True, check_bounds=True):
+                     ravel_group_idx=True, check_bounds=True, method="ravel"):
     """ Do some fairly extensive checking of group_idx and a, trying to
     give the user as much help as possible with what is wrong. Also,
     convert ndim-indexing to 1d indexing.
@@ -252,7 +275,7 @@ def input_validation(group_idx, a, size=None, order='C', axis=None,
             raise NotImplementedError("when using axis arg, size must be"
                                       "None or scalar.")
         else:
-            group_idx, size = _ravel_group_idx(group_idx, a, axis, size, order)
+            group_idx, size = _ravel_group_idx(group_idx, a, axis, size, order, method=method)
             flat_size = np.prod(size)
             ndim_idx = ndim_a
             return group_idx.ravel(), a.ravel(), flat_size, ndim_idx, size


### PR DESCRIPTION
I found that `ravel_multi_index` was taking a lot of time with reductions I tend to run; nD array, 1D group_idx, axis=-1 .

This is an alternate algorithm from https://stackoverflow.com/questions/46256279/bin-elements-per-row-vectorized-2d-bincount-for-numpy

I timed it with this script:
```python
import timeit

import numpy as np
import numpy_groupies as npg


def time_call(method):
    import numpy_groupies as npg

    group_idx = np.repeat([1, 2, 3, 4], repeats=3)
    times = []
    for exp in np.arange(6):
        a = np.ones(
            (
                10 ** exp,
                100,
                12,
            ),
            dtype=np.int32,
        )
        time = timeit.timeit(
            f"npg.utils_numpy.input_validation(group_idx, a, axis=-1, method={method!r})",
            number=10,
            globals=locals(),
        )

        times.append(time)

    np.testing.assert_array_equal(
        npg.utils_numpy.input_validation(group_idx, a, axis=-1, method="ravel")[0],
        npg.utils_numpy.input_validation(group_idx, a, axis=-1, method="offset")[0],
    )
    return times


ravel = time_call("ravel")
offset = time_call("offset")

import matplotlib.pyplot as plt

numel = 12 * 100 * 10**np.arange(len(ravel))
plt.plot(numel, ravel)
plt.plot(numel, offset)
plt.legend(["current npg", "proposed"])
plt.yscale("log")
plt.xscale("log")
plt.grid(True)
```
It's an ≈ 2x speedup for decent sized arrays
![image](https://user-images.githubusercontent.com/2448579/142691242-4a0096e0-7832-428a-9ff9-181d70bc7da3.png)
