### PR TITLE
Test for reduction along axis + fix arg*, cum* for form3

### DIFF
--- a/numpy_groupies/aggregate_numba.py
+++ b/numpy_groupies/aggregate_numba.py
@@ -38,6 +38,10 @@ class AggregateOp(object):
 
     def __call__(self, group_idx, a, size=None, fill_value=0, order='C',
                  dtype=None, axis=None, ddof=0):
+        needs_unravel = group_idx.ndim == 1 and a.ndim > 1 and "arg" in self.func and axis is not None
+        if needs_unravel:
+            orig_shape = a.shape
+
         iv = input_validation(group_idx, a, size=size, order=order, axis=axis, check_bounds=False)
         group_idx, a, flat_size, ndim_idx, size = iv
 
@@ -58,6 +62,9 @@ class AggregateOp(object):
 
         if self.outer:
             return outer
+
+        if needs_unravel:
+            ret = np.unravel_index(ret, orig_shape)[axis]
 
         # Deal with ndimensional indexing
         if ndim_idx > 1:

--- a/numpy_groupies/aggregate_numba.py
+++ b/numpy_groupies/aggregate_numba.py
@@ -38,7 +38,6 @@ class AggregateOp(object):
 
     def __call__(self, group_idx, a, size=None, fill_value=0, order='C',
                  dtype=None, axis=None, ddof=0):
-        is_argreduction = "arg" in self.func
         iv = input_validation(group_idx, a, size=size, order=order, axis=axis, check_bounds=False, func=self.func)
         group_idx, a, flat_size, ndim_idx, size, unravel_shape = iv
 
@@ -62,7 +61,8 @@ class AggregateOp(object):
 
         # Deal with ndimensional indexing
         if ndim_idx > 1:
-            if is_argreduction and axis is not None:
+            if unravel_shape is not None:
+                # argreductions only
                 ret = np.unravel_index(ret, unravel_shape)[axis]
             ret = ret.reshape(size, order=order)
         return ret

--- a/numpy_groupies/aggregate_numpy.py
+++ b/numpy_groupies/aggregate_numpy.py
@@ -152,7 +152,7 @@ def _var(group_idx, a, size, fill_value, dtype=np.dtype(np.float64),
         raise ValueError("cannot take variance with scalar a")
     counts = np.bincount(group_idx, minlength=size)
     sums = np.bincount(group_idx, weights=a, minlength=size)
-    with np.errstate(divide='ignore'):
+    with np.errstate(divide='ignore', invalid='ignore'):
         means = sums.astype(dtype) / counts
         ret = np.bincount(group_idx, (a - means[group_idx]) ** 2,
                           minlength=size) / (counts - ddof)

--- a/numpy_groupies/aggregate_numpy.py
+++ b/numpy_groupies/aggregate_numpy.py
@@ -254,7 +254,6 @@ def _aggregate_base(group_idx, a, func='sum', size=None, fill_value=0,
                     order='C', dtype=None, axis=None, _impl_dict=_impl_dict,
                     _nansqueeze=False, cache=None, **kwargs):
 
-    is_argreduction = not callable(func) and "arg" in func
     group_idx, a, flat_size, ndim_idx, size, unravel_shape = input_validation(group_idx, a,
                                                                size=size, order=order, axis=axis, func=func)
     if group_idx.dtype == np.dtype("uint64"):
@@ -284,7 +283,7 @@ def _aggregate_base(group_idx, a, func='sum', size=None, fill_value=0,
 
     # deal with ndimensional indexing
     if ndim_idx > 1:
-        if is_argreduction and axis is not None:
+        if unravel_shape is not None:
             ret = np.unravel_index(ret, unravel_shape)[axis]
         ret = ret.reshape(size, order=order)
     return ret

--- a/numpy_groupies/aggregate_numpy.py
+++ b/numpy_groupies/aggregate_numpy.py
@@ -253,6 +253,10 @@ _impl_dict.update(('nan' + k, v) for k, v in list(_impl_dict.items())
 def _aggregate_base(group_idx, a, func='sum', size=None, fill_value=0,
                     order='C', dtype=None, axis=None, _impl_dict=_impl_dict,
                     _nansqueeze=False, cache=None, **kwargs):
+
+    needs_unravel = group_idx.ndim == 1 and a.ndim > 1 and "arg" in func and axis is not None
+    if needs_unravel:
+        orig_shape = a.shape
     group_idx, a, flat_size, ndim_idx, size = input_validation(group_idx, a,
                                              size=size, order=order, axis=axis)
     if group_idx.dtype == np.dtype("uint64"):
@@ -279,6 +283,9 @@ def _aggregate_base(group_idx, a, func='sum', size=None, fill_value=0,
         func = _impl_dict[func]
         ret = func(group_idx, a, flat_size, fill_value=fill_value, dtype=dtype,
                    **kwargs)
+
+    if needs_unravel:
+        ret = np.unravel_index(ret, orig_shape)[axis]
 
     # deal with ndimensional indexing
     if ndim_idx > 1:

--- a/numpy_groupies/aggregate_numpy.py
+++ b/numpy_groupies/aggregate_numpy.py
@@ -253,8 +253,8 @@ _impl_dict.update(('nan' + k, v) for k, v in list(_impl_dict.items())
 def _aggregate_base(group_idx, a, func='sum', size=None, fill_value=0,
                     order='C', dtype=None, axis=None, _impl_dict=_impl_dict,
                     _nansqueeze=False, cache=None, **kwargs):
-    group_idx, a, flat_size, ndim_idx, size = input_validation(group_idx, a,
-                                                               size=size, order=order, axis=axis, func=func)
+    group_idx, a, flat_size, ndim_idx, size, unravel_shape = input_validation(group_idx, a,
+                                                                              size=size, order=order, axis=axis, func=func)
 
     if group_idx.dtype == np.dtype("uint64"):
         # Force conversion to signed int, to avoid issues with bincount etc later

--- a/numpy_groupies/tests/__init__.py
+++ b/numpy_groupies/tests/__init__.py
@@ -53,3 +53,8 @@ def _wrap_notimplemented_xfail(impl, name=None):
     else:
         _try_xfail.__name__ = impl.__name__
     return _try_xfail
+
+
+func_list = ('sum', 'prod', 'min', 'max', 'all', 'any', 'mean', 'std', 'var', 'len',
+             'argmin', 'argmax', 'anynan', 'allnan', 'cumsum',
+             'nansum', 'nanprod', 'nanmin', 'nanmax', 'nanmean', 'nanstd', 'nanvar','nanlen')

--- a/numpy_groupies/tests/test_compare.py
+++ b/numpy_groupies/tests/test_compare.py
@@ -10,7 +10,7 @@ import pytest
 
 from . import (aggregate_purepy, aggregate_numpy_ufunc, aggregate_numpy,
                aggregate_weave, aggregate_numba, aggregate_pandas,
-               _wrap_notimplemented_xfail, _impl_name)
+               _wrap_notimplemented_xfail, _impl_name, func_list)
 
 class AttrDict(dict):
     __getattr__ = dict.__getitem__
@@ -71,13 +71,6 @@ def func_preserve_order(iterator):
     for i, x in enumerate(iterator, 1):
         tmp += x ** i
     return tmp
-
-
-func_list = ('sum', 'prod', 'min', 'max', 'all', 'any', 'mean', 'std', 'var', 'len',
-             'argmin', 'argmax', 'anynan', 'allnan', 'cumsum', func_arbitrary, func_preserve_order,
-             'nansum', 'nanprod', 'nanmin', 'nanmax', 'nanmean', 'nanstd', 'nanvar','nanlen')
-
-
 @pytest.mark.parametrize(["func", "fill_value"], product(func_list, [0, 1, np.nan]),
                          ids=lambda x: getattr(x, '__name__', x))
 def test_cmp(aggregate_cmp, func, fill_value, decimal=10):

--- a/numpy_groupies/tests/test_generic.py
+++ b/numpy_groupies/tests/test_generic.py
@@ -340,8 +340,6 @@ def test_agg_along_axis(aggregate_all, size, func, axis):
 
     # TODO: These xfails need to be fixed...
     if len(size) > 1:
-        if func == "cumsum":
-            pytest.xfail()
         if func == "allnan":
             # This only fails for numba
             pytest.xfail()

--- a/numpy_groupies/tests/test_generic.py
+++ b/numpy_groupies/tests/test_generic.py
@@ -358,5 +358,5 @@ def test_argreduction_nD_array_1D_idx(aggregate_all):
     labels = np.array([0, 0, 2, 2, 2, 1, 1, 2, 2, 1, 1, 0], dtype=int)
     array = np.array([[1] * 12, [1] * 12])
     actual = aggregate_all(labels, array, axis=-1, func="argmax")
-    expected = np.array([[0,5,2], [0,5,2]])
+    expected = np.array([[0, 5, 2], [0, 5, 2]])
     np.testing.assert_equal(actual, expected)

--- a/numpy_groupies/tests/test_generic.py
+++ b/numpy_groupies/tests/test_generic.py
@@ -4,7 +4,7 @@ import itertools
 import numpy as np
 import pytest
 
-from . import _implementations, _impl_name, _wrap_notimplemented_xfail
+from . import _implementations, _impl_name, _wrap_notimplemented_xfail, func_list
 
 
 @pytest.fixture(params=_implementations, ids=_impl_name)
@@ -294,3 +294,71 @@ def test_sort(aggregate_all, order):
 
     res = aggregate_all(group_idx, a, func="sort", reverse=reverse)
     np.testing.assert_array_equal(res, ref)
+
+
+@pytest.mark.parametrize("axis", (0, 1))
+@pytest.mark.parametrize("size", ((12,), (12, 5)))
+@pytest.mark.parametrize("func", func_list)
+def test_agg_along_axis(aggregate_all, size, func, axis):
+    if len(size) == axis:
+        pytest.skip()
+
+    group_idx = np.zeros(size[axis], dtype=int)
+    array = np.random.randn(*size)
+
+    # add some NaNs to test out nan-skipping
+    if "nan" in func and "nanarg" not in func:
+        array[[1, 4, 5], ...] = np.nan
+    elif "nanarg" in func and array.ndim > 1:
+        array[[1, 4, 5], 1] = np.nan
+    if func in ["any", "all"]:
+        array = array > 0.5
+
+    # construct expected values for all cases
+    if func == "len":
+        expected = np.array(size[axis])
+    elif func == "nanlen":
+        expected = np.array((~np.isnan(array)).sum(axis=axis))
+    elif func == "anynan":
+        expected = np.isnan(array).any(axis=axis)
+    elif func == "allnan":
+        expected = np.isnan(array).all(axis=axis)
+    else:
+        with np.errstate(invalid="ignore", divide="ignore"):
+            expected = getattr(np, func)(array, axis=axis)
+
+    # The default fill_value is 0, the following makes the output
+    # match numpy
+    fill_values = {
+        "nanprod": 1,
+        "nanvar": np.nan,
+        "nanstd": np.nan,
+        "nanmax": np.nan,
+        "nanmin": np.nan,
+        "nanmean": np.nan,
+    }
+
+    # TODO: These xfails need to be fixed...
+    if len(size) > 1:
+        if func == "cumsum":
+            pytest.xfail()
+        if func == "allnan":
+            # This only fails for numba
+            pytest.xfail()
+
+    actual = aggregate_all(
+        group_idx, array, axis=axis, func=func, fill_value=fill_values.get(func, 0)
+    )
+    assert actual.ndim == array.ndim
+
+    # argmin, argmax don't support keepdims so we can't use that to construct expected
+    # instead we squeeze out the extra dims in actual.
+    np.testing.assert_allclose(actual.squeeze(), expected)
+
+def test_argreduction_nD_array_1D_idx(aggregate_all):
+    # regression test for GH41
+    labels = np.array([0, 0, 2, 2, 2, 1, 1, 2, 2, 1, 1, 0], dtype=int)
+    array = np.array([[1] * 12, [1] * 12])
+    actual = aggregate_all(labels, array, axis=-1, func="argmax")
+    expected = np.array([[0,5,2], [0,5,2]])
+    np.testing.assert_equal(actual, expected)

--- a/numpy_groupies/utils_numpy.py
+++ b/numpy_groupies/utils_numpy.py
@@ -276,12 +276,16 @@ def input_validation(group_idx, a, size=None, order='C', axis=None,
                                       "None or scalar.")
         else:
             is_form_3 = group_idx.ndim == 1 and a.ndim > 1 and axis is not None
-            unravel_shape = a.shape if is_form_3 else group_idx.shape
+            orig_shape = a.shape if is_form_3 else group_idx.shape
+            if "arg" in func:
+                unravel_shape = orig_shape
+            else:
+                unravel_shape = None
 
             group_idx, size = _ravel_group_idx(group_idx, a, axis, size, order, method=method)
             flat_size = np.prod(size)
             ndim_idx = ndim_a
-            size = unravel_shape if is_form_3 and not callable(func) and "cum" in func else size
+            size = orig_shape if is_form_3 and not callable(func) and "cum" in func else size
             return group_idx.ravel(), a.ravel(), flat_size, ndim_idx, size, unravel_shape
 
     if ndim_idx == 1:

--- a/numpy_groupies/utils_numpy.py
+++ b/numpy_groupies/utils_numpy.py
@@ -235,7 +235,7 @@ def offset_labels(group_idx, inshape, axis, order, size):
     return group_idx.reshape(inshape).ravel()
 
 def input_validation(group_idx, a, size=None, order='C', axis=None,
-                     ravel_group_idx=True, check_bounds=True, method="ravel"):
+                     ravel_group_idx=True, check_bounds=True, method="ravel", func=None):
     """ Do some fairly extensive checking of group_idx and a, trying to
     give the user as much help as possible with what is wrong. Also,
     convert ndim-indexing to 1d indexing.
@@ -275,10 +275,14 @@ def input_validation(group_idx, a, size=None, order='C', axis=None,
             raise NotImplementedError("when using axis arg, size must be"
                                       "None or scalar.")
         else:
+            is_form_3 = group_idx.ndim == 1 and a.ndim > 1 and axis is not None
+            unravel_shape = a.shape if is_form_3 else group_idx.shape
+
             group_idx, size = _ravel_group_idx(group_idx, a, axis, size, order, method=method)
             flat_size = np.prod(size)
             ndim_idx = ndim_a
-            return group_idx.ravel(), a.ravel(), flat_size, ndim_idx, size
+            size = unravel_shape if is_form_3 and not callable(func) and "cum" in func else size
+            return group_idx.ravel(), a.ravel(), flat_size, ndim_idx, size, unravel_shape
 
     if ndim_idx == 1:
         if size is None:
@@ -309,7 +313,7 @@ def input_validation(group_idx, a, size=None, order='C', axis=None,
         raise ValueError("group_idx and a must be of the same length, or a"
                          " can be scalar")
 
-    return group_idx, a, flat_size, ndim_idx, size
+    return group_idx, a, flat_size, ndim_idx, size, None
 
 
 ### General tools ###


### PR DESCRIPTION
Adds tests for reduction along a single axis (Form 3 primarily)

Fixes #41 

Remaining xfails are ~"cumsum",~ and "allnan" for numba (which returns the logical_not of the correct answer)