### PR TITLE
Don't convert duck arrays to numpy arrays

### DIFF
--- a/numpy_groupies/aggregate_numpy.py
+++ b/numpy_groupies/aggregate_numpy.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from .utils import check_boolean, funcs_no_separate_nan, get_func, aggregate_common_doc, isstr
 from .utils_numpy import (aliasing, minimum_dtype, input_validation,
-                          check_dtype, check_fill_value, minimum_dtype_scalar)
+                          check_dtype, check_fill_value, minimum_dtype_scalar, iscomplexobj)
 
 
 def _sum(group_idx, a, size, fill_value, dtype=None):
@@ -13,7 +13,7 @@ def _sum(group_idx, a, size, fill_value, dtype=None):
         if a != 1:
             ret *= a
     else:
-        if np.iscomplexobj(a):
+        if iscomplexobj(a):
             ret = np.empty(size, dtype=dtype)
             ret.real = np.bincount(group_idx, weights=a.real,
                                    minlength=size)
@@ -128,7 +128,7 @@ def _mean(group_idx, a, size, fill_value, dtype=np.dtype(np.float64)):
     if np.ndim(a) == 0:
         raise ValueError("cannot take mean with scalar a")
     counts = np.bincount(group_idx, minlength=size)
-    if np.iscomplexobj(a):
+    if iscomplexobj(a):
         dtype = a.dtype  # TODO: this is a bit clumsy
         sums = np.empty(size, dtype=dtype)
         sums.real = np.bincount(group_idx, weights=a.real,

--- a/numpy_groupies/utils_numpy.py
+++ b/numpy_groupies/utils_numpy.py
@@ -241,9 +241,10 @@ def input_validation(group_idx, a, size=None, order='C', axis=None,
     give the user as much help as possible with what is wrong. Also,
     convert ndim-indexing to 1d indexing.
     """
-    if not isinstance(a, (int, float, complex)):
+    if not isinstance(a, (int, float, complex)) and not is_duck_array(a):
         a = np.asanyarray(a)
-    group_idx = np.asanyarray(group_idx)
+    if not is_duck_array(group_idx):
+        group_idx = np.asanyarray(group_idx)
 
     if not np.issubdtype(group_idx.dtype, np.integer):
         raise TypeError("group_idx must be of integer type")
@@ -462,3 +463,19 @@ def relabel_groups_masked(group_idx, keep_group):
     relabel = np.zeros(keep_group.size, dtype=group_idx.dtype)
     relabel[keep_group] = np.arange(np.count_nonzero(keep_group))
     return relabel[group_idx]
+
+
+def is_duck_array(value) -> bool:
+    """
+    This function was copied from xarray/core/utils.py under the terms
+    of Xarray's Apache-2 license
+    """
+    if isinstance(value, np.ndarray):
+        return True
+    return (
+        hasattr(value, "ndim")
+        and hasattr(value, "shape")
+        and hasattr(value, "dtype")
+        and hasattr(value, "__array_function__")
+        and hasattr(value, "__array_ufunc__")
+    )

--- a/numpy_groupies/utils_numpy.py
+++ b/numpy_groupies/utils_numpy.py
@@ -479,3 +479,16 @@ def is_duck_array(value) -> bool:
         and hasattr(value, "__array_function__")
         and hasattr(value, "__array_ufunc__")
     )
+
+
+def iscomplexobj(x):
+    """
+    Copied from np.iscomplexobj so that we place fewer requirements
+    on duck array types.
+    """
+    try:
+        dtype = x.dtype
+        type_ = dtype.type
+    except AttributeError:
+        type_ = np.asarray(x).dtype.type
+    return issubclass(type_, np.complexfloating)


### PR DESCRIPTION
- [x] Closes #42 

This seems to be the simplest way that doesn't depend on numpy version 