### PR TITLE
Initial draft and benchmarking experiments with polars

### DIFF
--- a/numpy_groupies/aggregate_polars.py
+++ b/numpy_groupies/aggregate_polars.py
@@ -1,0 +1,48 @@
+from functools import partial
+
+import numpy as np
+import polars as pl
+
+from .aggregate_numpy import _aggregate_base
+from .utils import aggregate_common_doc, funcs_no_separate_nan, isstr
+from .utils_numpy import check_dtype
+
+
+def _wrapper(group_idx, a, size, fill_value, func='sum', dtype=None, ddof=0, **kwargs):
+    if isinstance(a, (int, float)):
+        a = np.full_like(group_idx, fill_value=a)
+    df = pl.DataFrame({'group_idx': group_idx, 'a': a})
+    funcname = func.__name__ if callable(func) else func
+    if funcname in ("array", "list"):
+        grouped = df.groupby('group_idx', maintain_order=True).agg_list()
+    elif func == funcname:
+        grouped = getattr(df.groupby('group_idx'), funcname)()
+    else:
+        grouped = df.groupby('group_idx').apply(func)
+    dtype = check_dtype(dtype, getattr(func, '__name__', funcname), a, size)
+    ret = np.full(size, fill_value, dtype=dtype)
+    res_field = 'count' if funcname == 'count' else 'a'
+    ret[grouped["group_idx"]] = grouped[res_field]
+    return ret
+
+
+_supported_funcs = 'sum min max mean first last'.split()
+_impl_dict = {fn: partial(_wrapper, func=fn) for fn in _supported_funcs}
+_impl_dict.update(('nan' + fn, partial(_wrapper, func=fn))
+                  for fn in _supported_funcs
+                  if fn not in funcs_no_separate_nan)
+_impl_dict.update(len=partial(_wrapper, func='count'),)
+
+
+def aggregate(group_idx, a, func='sum', size=None, fill_value=0, order='C',
+              dtype=None, axis=None, **kwargs):
+    return _aggregate_base(group_idx, a, size=size, fill_value=fill_value,
+                           order=order, dtype=dtype, func=func, axis=axis,
+                           _impl_dict=_impl_dict, **kwargs)
+
+
+aggregate.__doc__ = """
+    This is the polars implementation of aggregate. It makes use of
+    `polars`'s groupby machienery and is mainly used for reference
+    and benchmarking.
+    """ + aggregate_common_doc

--- a/numpy_groupies/benchmarks/generic.py
+++ b/numpy_groupies/benchmarks/generic.py
@@ -36,6 +36,7 @@ func_list = (np.sum, np.prod, np.min, np.max, len, np.all, np.any, 'anynan', 'al
              np.nanmean, np.nanvar, np.nanstd, 'nanfirst', 'nanlast', 'nanargmin',
              'nanargmax', 'cumsum', 'cumprod', 'cummax', 'cummin', arbitrary, 'sort')
 
+
 def benchmark_data(size=5e5, seed=100):
     rnd = np.random.RandomState(seed=seed)
     group_idx = rnd.randint(0, int(1e3), int(size))
@@ -97,9 +98,16 @@ def benchmark(implementations, repeat=5, size=5e5, seed=100, raise_errors=False)
     if 'pandas' in implementation_names:
         import pandas
         postfix += ', Pandas %s' % pandas.__version__
+    if 'polars' in implementation_names:
+        import polars
+        postfix += ', Polars %s' % polars.__version__
     print("%s(%s), Python %s, Numpy %s%s" % (platform.system(), platform.machine(), sys.version.split()[0], np.version.version, postfix))
 
 if __name__ == '__main__':
-    implementations = _implementations if '--purepy' in sys.argv else _implementations[1:]
-    implementations = implementations if '--pandas' in sys.argv else implementations[:-1]
-    benchmark(implementations, raise_errors=False)
+    used_implementations = _implementations.copy()
+    for impl_name in ("purepy", "pandas", "polars"):
+        # Those implementations should be specified explicitly on the command line
+        if '--' + impl_name not in sys.argv:
+            # Remove them from the chosen implementations, if not found
+            used_implementations = [i for i in used_implementations if impl_name not in i.__name__]
+    benchmark(used_implementations, raise_errors=False)

--- a/numpy_groupies/tests/__init__.py
+++ b/numpy_groupies/tests/__init__.py
@@ -13,9 +13,13 @@ try:
     from .. import aggregate_pandas
 except ImportError:
     aggregate_pandas = None
+try:
+    from .. import aggregate_polars
+except ImportError:
+    aggregate_polars = None
 
 _implementations = [aggregate_purepy, aggregate_numpy_ufunc, aggregate_numpy,
-                    aggregate_numba, aggregate_weave, aggregate_pandas]
+                    aggregate_numba, aggregate_weave, aggregate_pandas, aggregate_polars]
 _implementations = [i for i in _implementations if i is not None]
 
 
@@ -33,6 +37,7 @@ _not_implemented_by_impl_name = {
     'weave':  ('argmin', 'argmax', 'array', 'list', 'sort', 'cumsum', 'cummax', 'cummin',
                'nanargmin', 'nanargmax', 'sumofsquares', 'nansumofsquares',
                '<lambda>', 'custom_callable'),
+    'polars': 'NO_CHECK',
     'ufunc':  'NO_CHECK'}
 
 

--- a/numpy_groupies/tests/test_generic.py
+++ b/numpy_groupies/tests/test_generic.py
@@ -300,6 +300,9 @@ def test_nanargmin_nanargmax_nonans(aggregate_all):
 
 
 def test_min_max_inf(aggregate_all):
+    if aggregate_all.__name__.endswith('polars'):
+        pytest.xfail("polars doesn't use -inf as fill-value")
+
     # https://github.com/ml31415/numpy-groupies/issues/40
     res = aggregate_all(np.array([0, 1, 2, 0, 1, 2]),
                         np.array([-np.inf, 0, -np.inf, -np.inf, 0, 0]), func="max")


### PR DESCRIPTION
Out of curiosity, some benchmarking with the pandas-replacement [polars](https://github.com/pola-rs/polars).

```
function         ufunc         numpy         numba        pandas        polars
-------------------------------------------------------------------------------
sum              37.351         1.575         0.705        11.804         5.760
prod             37.858        38.116         0.696        11.855          ----
amin             39.217        39.006         0.690        11.708         5.723
amax             40.066        40.170         0.752        11.789         5.872
len              31.492         1.178         0.549        14.676         8.832
all              38.205         3.246         0.931        12.620          ----
any              35.562         5.778         0.883        12.918          ----
anynan           33.009         2.106         0.781       148.313          ----
allnan           34.309         5.157         0.878       151.105          ----
mean               ----         2.382         0.812        11.968         6.092
std                ----         4.213         0.953        12.030          ----
var                ----         4.140         0.941       121.457          ----
first              ----         2.010         0.968        12.389         5.150
last               ----         1.331         0.586        11.847         4.962
argmax             ----        41.329         0.889       345.678          ----
argmin             ----        43.901         1.025       345.023          ----
nansum             ----         5.538         1.725        15.199         8.535
nanprod            ----        34.893         1.754        14.575          ----
nanmin             ----        35.320         1.651        15.547         8.803
nanmax             ----        36.634         1.696        15.000         8.445
nanlen             ----         4.999         1.504        14.531          ----
nanall             ----         6.981         1.945        15.847          ----
nanany             ----         8.521         2.003        16.325          ----
nanmean            ----         5.824         1.789        15.173         9.036
nanvar             ----         7.323         1.632       119.184          ----
nanstd             ----         8.609         1.630        14.872          ----
nanfirst           ----         5.465         2.001        14.852         7.946
nanlast            ----         5.090         1.505        14.619         8.370
nanargmin          ----        46.446         1.888       352.186          ----
nanargmax          ----        42.876         1.964       346.221          ----
cumsum             ----       118.612         1.393         7.728          ----
cumprod            ----          ----         1.157        11.106          ----
cummax             ----          ----         1.083        11.668          ----
cummin             ----          ----         1.043        11.375          ----
arbitrary          ----       144.194        45.318       125.090       147.434
sort               ----       172.135          ----          ----          ----
Linux(x86_64), Python 3.10.6, Numpy 1.23.4, Numba 0.56.3, Pandas 1.4.3, Polars 0.14.23

```