### PR TITLE
Use faster group_idx creation when axis == -1

### DIFF
--- a/numpy_groupies/utils_numpy.py
+++ b/numpy_groupies/utils_numpy.py
@@ -277,7 +277,6 @@ def input_validation(
     axis=None,
     ravel_group_idx=True,
     check_bounds=True,
-    method="ravel",
     func=None,
 ):
     """Do some fairly extensive checking of group_idx and a, trying to
@@ -331,6 +330,7 @@ def input_validation(
             else:
                 unravel_shape = None
 
+            method = "offset" if axis == ndim_a - 1 else "ravel"
             group_idx, size = _ravel_group_idx(
                 group_idx, a, axis, size, order, method=method
             )


### PR DESCRIPTION
xref https://github.com/xarray-contrib/flox/issues/222 
xref #46
xref #51
xref #60

Uses the faster algorithm from #46 only when `axis == -1` I couldn't make it work in general.
