### PR TITLE
Adding py3.12 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: CI
 on:
   push:
     branches:
-      - "main"
+      - "master"
   pull_request:
     branches:
       - "*"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
           environment-name: xarray-tests
           cache-environment: true
           cache-environment-key: "${{runner.os}}-${{runner.arch}}-py${{matrix.python-version}}-${{hashFiles(env.CONDA_ENV_FILE)}}"
-          create-args: |
+          create-args: >-
             python=${{matrix.python-version}}
             conda
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
         uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: ${{ env.CONDA_ENV_FILE }}
-          environment-name: xarray-tests
+          environment-name: npg-tests
           cache-environment: true
           cache-environment-key: "${{runner.os}}-${{runner.arch}}-py${{matrix.python-version}}-${{hashFiles(env.CONDA_ENV_FILE)}}"
           create-args: >-

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,13 +36,13 @@ jobs:
           echo "PYTHON_VERSION=${{ matrix.python-version }}" >> $GITHUB_ENV
 
       - name: Setup micromamba
-        uses: mamba-org/provision-with-micromamba@v15
+        uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: ${{ env.CONDA_ENV_FILE }}
           environment-name: xarray-tests
-          cache-env: true
-          cache-env-key: "${{runner.os}}-${{runner.arch}}-py${{matrix.python-version}}-${{hashFiles(env.CONDA_ENV_FILE)}}"
-          extra-specs: |
+          cache-environment: true
+          cache-environment-key: "${{runner.os}}-${{runner.arch}}-py${{matrix.python-version}}-${{hashFiles(env.CONDA_ENV_FILE)}}"
+          create-args: |
             python=${{matrix.python-version}}
             conda
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: CI
 on:
   push:
     branches:
-      - "*"
+      - "main"
   pull_request:
     branches:
       - "*"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![GitHub Workflow CI Status](https://img.shields.io/github/actions/workflow/status/ml31415/numpy-groupies/ci.yaml?branch=master&logo=github&style=flat)](https://github.com/ml31415/numpy-groupies/actions)
 [![PyPI](https://img.shields.io/pypi/v/numpy-groupies.svg?style=flat)](https://pypi.org/project/numpy-groupies/)
 [![Conda-forge](https://img.shields.io/conda/vn/conda-forge/numpy_groupies.svg?style=flat)](https://anaconda.org/conda-forge/numpy_groupies)
+[![Supported Versions](https://img.shields.io/pypi/pyversions/numpy-groupies.svg)](https://pypi.org/project/numpy-groupies)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 # numpy-groupies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering",
     "Topic :: Software Development :: Libraries",
     "License :: OSI Approved :: BSD License",


### PR DESCRIPTION
Updades for py.3.12. Looks like the mamba xarray-tests environment isn't set up yet.

```
  /home/runner/micromamba-bin/micromamba create -y -r /home/runner/micromamba -f ci/environment.yml -n xarray-tests python=3.12 conda --log-level warning --rc-file /home/runner/micromamba-bin/.condarc
  error    libmamba Could not solve for environment specs
      The following packages are incompatible
      ├─ conda is installable with the potential options
      │  ├─ conda [22.11.1|22.9.0|...|4.14.0] would require
      │  │  └─ python_abi 3.10.* *_cp310, which can be installed;
      │  ├─ conda [22.11.1|22.9.0|...|23.9.0] would require
      │  │  └─ python_abi 3.11.* *_cp311, which can be installed;
      │  ├─ conda [22.9.0|4.10.0|...|4.9.2] would require
      │  │  └─ python_abi 3.7.* *_cp37m, which can be installed;
      │  ├─ conda [22.11.1|22.9.0|4.14.0] would require
      │  │  └─ python_abi 3.8 *_pypy38_pp73, which can be installed;
      │  ├─ conda [22.11.1|22.9.0|...|4.9.2] would require
      │  │  └─ python_abi 3.8.* *_cp38, which can be installed;
      │  ├─ conda [22.11.1|22.9.0|4.14.0] would require
      │  │  └─ python_abi 3.9 *_pypy39_pp73, which can be installed;
      │  ├─ conda [22.11.1|22.9.0|...|4.9.2] would require
      │  │  └─ python_abi 3.9.* *_cp39, which can be installed;
      │  ├─ conda [4.1.11|4.1.12|...|4.8.2] would require
      │  │  └─ python [2.7* |>=2.7,<2.8.0a0 ], which can be installed;
      │  ├─ conda [4.1.11|4.1.12|4.2.13] would require
      │  │  └─ python 3.4* , which can be installed;
      │  ├─ conda [4.1.11|4.1.12|...|4.5.9] would require
      │  │  └─ python [3.5* |>=3.5,<3.6.0a0 ], which can be installed;
      │  ├─ conda [4.10.0|4.10.1|...|4.9.2] would require
      │  │  └─ python_abi 3.6.* *_cp36m, which can be installed;
      │  ├─ conda [4.10.0|4.10.1|...|4.9.2] would require
      │  │  └─ python_abi 3.6 *_pypy36_pp73, which can be installed;
      │  ├─ conda [4.10.1|4.10.2|...|4.13.0] would require
      │  │  └─ python_abi 3.7 *_pypy37_pp73, which can be installed;
      │  ├─ conda [4.2.13|4.3.21|...|4.5.1] would require
      │  │  └─ python 3.6* , which can be installed;
      │  ├─ conda [4.5.10|4.5.11|...|4.8.2] would require
      │  │  └─ python >=3.6,<3.7.0a0 , which can be installed;
      │  ├─ conda [4.5.11|4.5.12|...|4.8.2] would require
      │  │  └─ python >=3.7,<3.8.0a0 , which can be installed;
      │  ├─ conda [4.7.12|4.8.0|4.8.2] would require
      │  │  └─ python >=3.8,<3.9.0a0 , which can be installed;
      │  ├─ conda 4.8.3 would require
      │  │  └─ python_abi 2.7.* *_cp27mu, which can be installed;
      │  ├─ conda [23.1.0|23.3.0|...|23.7.3] would require
      │  │  └─ pypy3.8 >=7.3.11 , which can be installed;
      │  ├─ conda [23.1.0|23.3.0|...|23.7.3] would require
      │  │  └─ pypy3.9 >=7.3.11 , which can be installed;
      │  ├─ conda 23.7.4 would require
      │  │  └─ pypy3.9 >=7.3.12 , which can be installed;
      │  └─ conda 23.9.0 would require
      │     └─ pypy3.9 >=7.3.13 , which can be installed;
      └─ python 3.12**  is not installable because there are no viable options
         ├─ python 3.12.0 would require
         │  └─ python_abi 3.12.* *_cp312, which conflicts with any installable versions previously reported;
         └─ python 3.12.0rc3 would require
            └─ _python_rc, which does not exist (perhaps a missing channel).
  critical libmamba Could not solve for environment specs
  Error: The process '/home/runner/micromamba-bin/micromamba' failed with exit code 1
  ```
  @dcherian any ideas?